### PR TITLE
AVNZ-10: add pre-push hook and README/SUMMARY docs

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[pre-push] Running repo hygiene checks..."
+
+MAX_BYTES=$((50 * 1024 * 1024))
+
+if git ls-files | grep -E '(^|/)node_modules/|(^|/)\.next/' >/dev/null 2>&1; then
+  echo "[pre-push] ERROR: Tracked files under node_modules/ or .next/ detected. Remove them before pushing."
+  exit 1
+fi
+
+large_files=$(git ls-tree -r -l HEAD | awk -v max="$MAX_BYTES" '$4 ~ /^-/ && $3 ~ /^[0-9]+$/ { if ($3 > max) print $4" ("$3" bytes)" }')
+if [ -n "$large_files" ]; then
+  echo "[pre-push] ERROR: Large files (>50MB) in HEAD:"
+  echo "$large_files"
+  echo "Use Git LFS or remove them from history."
+  exit 1
+fi
+
+echo "[pre-push] Hygiene checks passed."
+

--- a/README.md
+++ b/README.md
@@ -61,9 +61,13 @@ Start-of-session checklist (Codex/agents)
 
 Note: Brave Mode is the default in this repo. Agents run the above Docker and script commands automatically without asking. Destructive actions (like volume prune) are still called out explicitly unless the user has already consented within the session.
 
-Git hooks (optional)
-- You can enable the included pre-commit hook to run lint automatically before commits:
+Git hooks (optional but recommended)
+- Enable repo hooks once per clone:
   - `git config core.hooksPath .githooks`
+- What they do:
+  - `pre-commit`: runs lint; blocks committing `node_modules/`, `.next/`, and files > 50MB.
+  - `pre-push`: blocks pushing if `HEAD` contains `node_modules/`, `.next/`, or files > 50MB.
+  - These guardrails reinforce `.gitignore` and GitHub’s 100MB limit.
 
 ## Pre‑push Requirements
 - You must run and pass all checks locally before pushing:

--- a/SUMMARY.MD
+++ b/SUMMARY.MD
@@ -258,6 +258,11 @@ Update 2025-09-27 (Jira Backlog)
 - No code/runtime changes. Purpose is to queue work via the tasks menu/Jira without impacting services.
 
 Update 2025-09-27 (Jira RPS automation)
+Update 2025-09-28 (Repo Hygiene Hooks)
+- Added Git hooks to enforce repo hygiene locally:
+  - `pre-commit`: runs lint; blocks committing `node_modules/`, `.next/`, and files > 50MB.
+  - `pre-push`: blocks pushing when `HEAD` contains `node_modules/`, `.next/`, or files > 50MB.
+- Enable with `git config core.hooksPath .githooks`. README updated under "Git hooks".
 - Added `scripts/jira-import-rps.sh` to programmatically create the RPS Epic and child tasks in Jira (project `AVNZ`) and assign them to Emma Johansson.
 - Implementation notes:
   - Uses Basic auth with `JIRA_EMAIL`/`JIRA_API_TOKEN`/`JIRA_DOMAIN`.


### PR DESCRIPTION
Adds .githooks/pre-push to block disallowed paths (node_modules/.next) and files >50MB at push time. Documents hooks in README and records change in SUMMARY. No app code changes.